### PR TITLE
Fix: 修复 Microsoft 登录序列化 JSON 时使用 CamelCase 导致 BadRequest 的严重问题，再次完善皮肤获取器

### DIFF
--- a/Authentication/MicrosoftAuthentication.cs
+++ b/Authentication/MicrosoftAuthentication.cs
@@ -206,8 +206,12 @@ public class MicrosoftAuthentication
             RelyingParty = "http://auth.xboxlive.com",
             TokenType = "JWT"
         };
+        var options = new JsonSerializerOptions()
+        {
+            WriteIndented = true
+        };
 
-        var xblLoginContentString = xboxLoginContent.Serialize();
+        var xblLoginContentString = xboxLoginContent.Serialize(options);
 
         string xboxResponseString;
 
@@ -238,7 +242,7 @@ public class MicrosoftAuthentication
             TokenType = "JWT"
         };
 
-        var xstsPostData = getXstsJsonData.Serialize();
+        var xstsPostData = getXstsJsonData.Serialize(options);
 
         var xstsResponse = await HttpUtil.SendHttpPostRequest("https://xsts.auth.xboxlive.com/xsts/authorize",
             xstsPostData, "application/json");

--- a/Skin/Fetchers/MicrosoftSkinFetcher.cs
+++ b/Skin/Fetchers/MicrosoftSkinFetcher.cs
@@ -13,7 +13,7 @@ public class MicrosoftSkinFetcher
     /// <summary>
     /// 获取微软皮肤
     /// </summary>
-    /// <param name="account">皮肤图片字节信息</param>
+    /// <param name="account">微软账户</param>
     /// <returns>皮肤图片字节信息</returns>
     public static async Task<byte[]> GetMicrosoftSkinAsync(MicrosoftAccount account)
     {

--- a/Skin/Fetchers/UnifiedPassSkinFetcher.cs
+++ b/Skin/Fetchers/UnifiedPassSkinFetcher.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using StarLight_Core.Models.Authentication;
 using StarLight_Core.Models.Skin;
 using StarLight_Core.Utilities;
 
@@ -12,9 +13,19 @@ public class UnifiedPassSkinFetcher
     /// <summary>
     /// 获取统一通行证皮肤
     /// </summary>
-    /// <param name="uuid">微软账户 Uuid</param>
+    /// <param name="account">统一通行证账户</param>
     /// <returns>皮肤图片字节信息</returns>
-    public static async Task<byte[]> GetMicrosoftUnifiedPassSkinAsync(string uuid)
+    public static async Task<byte[]> GetUnifiedPassSkinAsync(UnifiedPassAccount account)
+    {
+        return await GetUnifiedPassSkinAsync(account.Uuid);
+    }
+
+    /// <summary>
+    /// 获取统一通行证皮肤
+    /// </summary>
+    /// <param name="uuid">统一通行证账户 Uuid</param>
+    /// <returns>皮肤图片字节信息</returns>
+    public static async Task<byte[]> GetUnifiedPassSkinAsync(string uuid)
     {
         const string baseUrl = "https://auth.mc-user.com:233/sessionserver/session/minecraft/profile/";
         var skinJson = await HttpUtil.GetStringAsync(baseUrl + uuid);

--- a/Skin/SkinProcessor.cs
+++ b/Skin/SkinProcessor.cs
@@ -30,7 +30,7 @@ public class SkinProcessor
     /// <param name="base64Image"></param>
     /// <param name="outputFilePath"></param>
     /// <param name="isDecoration"></param>
-    public static void GetLiftLeg(string base64Image, string outputFilePath, bool isDecoration = false)
+    public static void GetLeftLeg(string base64Image, string outputFilePath, bool isDecoration = false)
     {
         var imageBytes = Convert.FromBase64String(base64Image);
 
@@ -126,7 +126,7 @@ public class SkinProcessor
     /// <param name="base64Image"></param>
     /// <param name="outputFilePath"></param>
     /// <param name="isDecoration"></param>
-    public static void GetLiftArm_Alex(string base64Image, string outputFilePath, bool isDecoration = false)
+    public static void GetLeftArm_Alex(string base64Image, string outputFilePath, bool isDecoration = false)
     {
         var imageBytes = Convert.FromBase64String(base64Image);
 
@@ -222,7 +222,7 @@ public class SkinProcessor
     /// <param name="base64Image"></param>
     /// <param name="outputFilePath"></param>
     /// <param name="isDecoration"></param>
-    public static void GetLiftArm_Steve(string base64Image, string outputFilePath, bool isDecoration = false)
+    public static void GetLeftArm_Steve(string base64Image, string outputFilePath, bool isDecoration = false)
     {
         var imageBytes = Convert.FromBase64String(base64Image);
 

--- a/StarLight.Core.sln
+++ b/StarLight.Core.sln
@@ -5,8 +5,6 @@ VisualStudioVersion = 18.6.11819.183 stable
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StarLight.Core", "StarLight.Core.csproj", "{31804C47-220A-4EBA-85E4-041D2153D853}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SLDemo", "C:\Users\Xu Zimu\source\repos\SLDemo\SLDemo.csproj", "{67E6FCF2-CCB2-A954-A20E-83AAAE59259F}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/StarLight.Core.sln
+++ b/StarLight.Core.sln
@@ -1,8 +1,11 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.7.34202.233
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 18
+VisualStudioVersion = 18.6.11819.183 stable
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StarLight.Core", "StarLight.Core.csproj", "{31804C47-220A-4EBA-85E4-041D2153D853}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SLDemo", "C:\Users\Xu Zimu\source\repos\SLDemo\SLDemo.csproj", "{67E6FCF2-CCB2-A954-A20E-83AAAE59259F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,6 +17,10 @@ Global
 		{31804C47-220A-4EBA-85E4-041D2153D853}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{31804C47-220A-4EBA-85E4-041D2153D853}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{31804C47-220A-4EBA-85E4-041D2153D853}.Release|Any CPU.Build.0 = Release|Any CPU
+		{67E6FCF2-CCB2-A954-A20E-83AAAE59259F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{67E6FCF2-CCB2-A954-A20E-83AAAE59259F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{67E6FCF2-CCB2-A954-A20E-83AAAE59259F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{67E6FCF2-CCB2-A954-A20E-83AAAE59259F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/StarLight.Core.sln
+++ b/StarLight.Core.sln
@@ -15,10 +15,6 @@ Global
 		{31804C47-220A-4EBA-85E4-041D2153D853}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{31804C47-220A-4EBA-85E4-041D2153D853}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{31804C47-220A-4EBA-85E4-041D2153D853}.Release|Any CPU.Build.0 = Release|Any CPU
-		{67E6FCF2-CCB2-A954-A20E-83AAAE59259F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{67E6FCF2-CCB2-A954-A20E-83AAAE59259F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{67E6FCF2-CCB2-A954-A20E-83AAAE59259F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{67E6FCF2-CCB2-A954-A20E-83AAAE59259F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/StarLight.Core.sln
+++ b/StarLight.Core.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 18
-VisualStudioVersion = 18.6.11819.183 stable
+# Visual Studio Version 17
+VisualStudioVersion = 17.7.34202.233
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StarLight.Core", "StarLight.Core.csproj", "{31804C47-220A-4EBA-85E4-041D2153D853}"
 EndProject

--- a/Utilities/JsonUtil.cs
+++ b/Utilities/JsonUtil.cs
@@ -79,11 +79,12 @@ public static class JsonUtil
     /// 将对象序列化为 JSON 字符串
     /// </summary>
     /// <param name="obj">要序列化的对象</param>
+    /// <param name="options">可选的序列化选项</param>
     /// <returns>表示对象的 JSON 字符串；若 <paramref name="obj"/> 为 null，则返回字符串 "null"</returns>
     /// <exception cref="ArgumentNullException">当 <paramref name="obj"/> 为 null 时抛出</exception>
-    public static string Serialize(this object? obj)
+    public static string Serialize(this object? obj, JsonSerializerOptions? options = null)
     {
-        return obj is null ? throw new ArgumentNullException(nameof(obj)) : JsonSerializer.Serialize(obj, Options);
+        return obj is null ? throw new ArgumentNullException(nameof(obj)) : JsonSerializer.Serialize(obj, options ?? Options);
     }
 
     /// <summary>
@@ -95,7 +96,7 @@ public static class JsonUtil
     /// </returns>
     /// <exception cref="JsonException">JSON 字符串格式无效时抛出</exception>
     public static JsonNode? ToJsonNode(this string json) => JsonNode.Parse(json);
-    
+
     /// <summary>
     /// 将 JSON 字符串解析为 <see cref="JsonDocument"/> 对象
     /// </summary>


### PR DESCRIPTION
1. 修复 Microsoft 登录序列化 JSON 时使用 `CamelCase` 导致 `BadRequest` 的严重问题；
- 由于使用 `CamelCase` 导致序列化后的 JSON 不符合 XBL、XSTS 接受的参数（如 `Properties` 意外变为 `properties`），该问题现已修复；
- 现在 `Serialize` 扩展方法接受新的 `JsonSerializerOptions?`，不填默认使用 `Options` 只读变量。
2. 为统一通行证皮肤获取器 `UnifiedPassSkinFetcher` 添加接受 `UnifiedPassAccount` 的方法，修复部分 XML 注释。